### PR TITLE
V2-3583 SDK method menus.get() does not accurately return external links

### DIFF
--- a/references/sdk/README.md
+++ b/references/sdk/README.md
@@ -165,13 +165,15 @@ utils.client.menus.get()
             "id": "",
             "items": [],
             "name": "",
-            "slug": "",
-            "type": ""
+            "url": "https://",
+            "type": "link"
         }],
         "updatedOn": "" // iso date string
     }]
 }
 ```
+
+**Note:** menu item will have a `url` if it is of `type` `"link"`, otherwise it will have a slug.
 
 ### Products
 


### PR DESCRIPTION
https://volusion-product-team.atlassian.net/browse/V2-3583

- clarification about menu item `slug` vs. `url`